### PR TITLE
Add Bootstrap base templates

### DIFF
--- a/dossiers/templates/dossiers/index.html
+++ b/dossiers/templates/dossiers/index.html
@@ -1,17 +1,19 @@
-<html lang="en">{% load static %}
-  <head>
-    <meta charset="UTF-8" />
-    <title>Dossiers</title>
-  </head>
-  <body>
-    <h1>Suspects</h1>
-    <p>Choose a criminal:</p>
-    <ul>
-      {% for suspect in suspects %}
-      <li>
-        <img src="{% get_static_prefix %}criminals/img/{{ suspect.name }}.jpg" width="200"/>
-        <a href="{% url 'dossiers:suspect' suspect.name %}">{{ suspect.name }}</a></li>
-      {% endfor %}
-    </ul>
-  </body>
-</html>
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}Dossiers{% endblock %}
+
+{% block content %}
+  <h1 class="mb-4">Suspects</h1>
+  <p>Choose a criminal:</p>
+  <div class="row">
+    {% for suspect in suspects %}
+      <div class="col-6 col-md-4 col-lg-3 mb-4 text-center">
+        {% if suspect.has_picture %}
+          <img src="{% get_static_prefix %}criminals/img/{{ suspect.name }}.jpg" class="img-fluid mb-2" alt="{{ suspect.name }}" />
+        {% endif %}
+        <h5><a href="{% url 'dossiers:suspect' suspect.name %}">{{ suspect.name }}</a></h5>
+      </div>
+    {% endfor %}
+  </div>
+{% endblock %}

--- a/dossiers/templates/dossiers/suspect.html
+++ b/dossiers/templates/dossiers/suspect.html
@@ -1,25 +1,26 @@
-<html lang="en">{% load static %}
-  <head>
-    <meta charset="UTF-8" />
-    <title>{{ suspect.name }}</title>
-  </head>
-  <body>
-    <h1>{{ suspect.name }}</h1>
-    <img src="{% get_static_prefix %}criminals/img/{{ suspect.name }}.jpg" width="400"/>
-    <dl>
-        <dt>Auto:</dt>
-        <dd>{{ suspect.get_auto_display|default:"Unknown" }}</dd>
-        <dt>Feature:</dt> 
-        <dd>{{ suspect.get_feature_display|default:"Unknown" }}</dd>
-        <dt>Hair:</dt> 
-        <dd>{{ suspect.get_hair_display|default:"Unknown" }}</dd>
-        <dt>Hobby:</dt> 
-        <dd>{{ suspect.get_hobby_display|default:"Unknown" }}</dd>
-        <dt>Sex:</dt> 
-        <dd>{{ suspect.get_sex_display|default:"Unknown" }}</dd>
-        <dt>Food:</dt> 
-        <dd>{{ suspect.get_food_display|default:"Unknown" }}</dd>
-    </dl>
-    <p><a href="{% url 'dossiers:index' %}">All suspects</a></p>
-  </body>
-</html>
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}{{ suspect.name }}{% endblock %}
+
+{% block content %}
+  <h1 class="mb-4">{{ suspect.name }}</h1>
+  {% if suspect.has_picture %}
+    <img src="{% get_static_prefix %}criminals/img/{{ suspect.name }}.jpg" class="img-fluid mb-3" alt="{{ suspect.name }}" />
+  {% endif %}
+  <dl class="row">
+      <dt class="col-sm-3">Auto</dt>
+      <dd class="col-sm-9">{{ suspect.get_auto_display|default:"Unknown" }}</dd>
+      <dt class="col-sm-3">Feature</dt>
+      <dd class="col-sm-9">{{ suspect.get_feature_display|default:"Unknown" }}</dd>
+      <dt class="col-sm-3">Hair</dt>
+      <dd class="col-sm-9">{{ suspect.get_hair_display|default:"Unknown" }}</dd>
+      <dt class="col-sm-3">Hobby</dt>
+      <dd class="col-sm-9">{{ suspect.get_hobby_display|default:"Unknown" }}</dd>
+      <dt class="col-sm-3">Sex</dt>
+      <dd class="col-sm-9">{{ suspect.get_sex_display|default:"Unknown" }}</dd>
+      <dt class="col-sm-3">Food</dt>
+      <dd class="col-sm-9">{{ suspect.get_food_display|default:"Unknown" }}</dd>
+  </dl>
+  <p><a href="{% url 'dossiers:index' %}" class="btn btn-secondary">All suspects</a></p>
+{% endblock %}

--- a/factbook/templates/factbook/country.html
+++ b/factbook/templates/factbook/country.html
@@ -1,16 +1,14 @@
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <title>{{ country.name }}</title>
-  </head>
-  <body>
-    <h1>{{ country.common_name }}</h1>
-    {% if country.common_name != country.name %}
-      <h2>{{ country.name }}</h2>
-    {% endif %}
-    <p>Currency: {{ country.currency }}</p>
-    <p>Flag: {% for each in country.flag_colours.all %}{{ each.colour }}{% if not forloop.last %}, {% endif %}{% endfor %}</p>
-    <p>Geography: {{ country.geography }}</p>
-    <p><a href="{% url 'factbook:index' %}">All countries</a></p>
-  </body>
-</html>
+{% extends 'base.html' %}
+
+{% block title %}{{ country.name }}{% endblock %}
+
+{% block content %}
+  <h1 class="mb-3">{{ country.common_name }}</h1>
+  {% if country.common_name != country.name %}
+    <h2 class="h5 text-muted">{{ country.name }}</h2>
+  {% endif %}
+  <p><strong>Currency:</strong> {{ country.currency }}</p>
+  <p><strong>Flag:</strong> {% for each in country.flag_colours.all %}{{ each.colour }}{% if not forloop.last %}, {% endif %}{% endfor %}</p>
+  <p><strong>Geography:</strong> {{ country.geography }}</p>
+  <p><a href="{% url 'factbook:index' %}" class="btn btn-secondary">All countries</a></p>
+{% endblock %}

--- a/factbook/templates/factbook/index.html
+++ b/factbook/templates/factbook/index.html
@@ -1,17 +1,15 @@
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <title>Factbook</title>
-  </head>
-  <body>
-    <h1>Factbook</h1>
-    <p>Choose a country:</p>
-    <ul>
-      {% for country in countries %}
-      <li>
-        <a href="{% url 'factbook:country' country.code %}">{{ country.common_name }}</a>
-      </li>
-      {% endfor %}
-    </ul>
-  </body>
-</html>
+{% extends 'base.html' %}
+
+{% block title %}Factbook{% endblock %}
+
+{% block content %}
+  <h1 class="mb-4">Factbook</h1>
+  <p>Choose a country:</p>
+  <ul class="list-group">
+    {% for country in countries %}
+    <li class="list-group-item">
+      <a href="{% url 'factbook:country' country.code %}">{{ country.common_name }}</a>
+    </li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}Global Detective Quest{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    {% block extra_css %}{% endblock %}
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{% url 'index' %}">Global Detective</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item"><a class="nav-link" href="{% url 'dossiers:index' %}">Dossiers</a></li>
+            <li class="nav-item"><a class="nav-link" href="{% url 'factbook:index' %}">World Fact Book</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <div class="container my-4">
+      {% block content %}{% endblock %}
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    {% block extra_js %}{% endblock %}
+  </body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,14 +1,11 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <title>Global Detective Quest</title>
-  </head>
-  <body>
-    <h1>Global Detective Quest</h1>
-    <ul>
-      <li><a href="{% url 'dossiers:index' %}">Dossiers</a></li>
-      <li><a href="{% url 'factbook:index' %}">World Fact Book</a></li>
-    </ul>
-  </body>
-</html>
+{% extends 'base.html' %}
+
+{% block title %}Global Detective Quest{% endblock %}
+
+{% block content %}
+  <h1 class="mb-4">Global Detective Quest</h1>
+  <ul class="list-group">
+    <li class="list-group-item"><a href="{% url 'dossiers:index' %}">Dossiers</a></li>
+    <li class="list-group-item"><a href="{% url 'factbook:index' %}">World Fact Book</a></li>
+  </ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- introduce `base.html` with Bootstrap styling and responsive navbar
- update all pages to extend the new base template
- display suspect and country details using Bootstrap classes for mobile-first layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843dd112d2c8324977aef2f59af3883